### PR TITLE
Slope

### DIFF
--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: akgfmaps
 Type: Package
 Title: Alaska groundfish mapping
-Version: 2.1.0
+Version: 2.2.0
 Authors@R: c(person("Sean", "Rohan", email = "sean.rohan@noaa.gov", role = c("aut", "cre")),
     person("Emily", "Markowitz", email = "emily.markowitz@noaa.gov", role = "ctb"),
     person("Jason", "Conner", email = "jason.conner@noaa.gov", role = "ctb"),

--- a/R/get_base_layers.R
+++ b/R/get_base_layers.R
@@ -1,7 +1,7 @@
 #' Function to get base layers for plotting
 #' 
 #' This function loads often-used layers used for plotting the eastern Bering Sea continental shelf.
-#' @param select.region Character vector indicating which region. Options = ebs or bs.all, sebs or bs.south, nbs or bs.north, ebs.slope, ecs, ebs.ecs, ai, ai.west, ai.central, ai.east, goa, goa.west, goa.east
+#' @param select.region Character vector indicating which region. Options = ebs or bs.all, sebs or bs.south, nbs or bs.north, ecs, ebs.ecs, ai, ai.west, ai.central, ai.east, goa, goa.west, goa.east, ebs.slope, bssa1, bssa2, bssa3, bssa4, bssa5, bssa6
 #' @param set.crs Which coordinate reference system should be used? If 'auto', an Albers Equal Area coordinate reference system is automatically assigned.
 #' @param use.survey.bathymetry Should survey bathymetry be used?
 #' @return A list containing sf objects land, bathymetry, survey area boundary, survey strata, survey grid (optional), a data frame of feature labels, coordinate reference system for all objects, and a suggested boundary.
@@ -29,6 +29,12 @@ get_base_layers <- function(select.region,
       "+proj=aea +lat_1=54.4 +lat_2=57.6 +lat_0=56 +lon_0=-149.25 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
       "+proj=aea +lat_1=54.4 +lat_2=57.6 +lat_0=56 +lon_0=-149.25 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
       "+proj=aea +lat_1=54.4 +lat_2=57.6 +lat_0=56 +lon_0=-149.25 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
+      "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs",
       "+proj=aea +lat_1=57 +lat_2=63 +lat_0=59 +lon_0=-170 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs")
     set.crs <- region.crs[match(select.region, c("bs.south", 
                                                  "sebs", 
@@ -45,7 +51,13 @@ get_base_layers <- function(select.region,
                                                  "goa",
                                                  "goa.west",
                                                  "goa.east",
-                                                 "ebs.slope"))]
+                                                 "ebs.slope",
+                                                 "bssa1",
+                                                 "bssa2",
+                                                 "bssa3",
+                                                 "bssa4",
+                                                 "bssa5",
+                                                 "bssa6"))]
   }
 
   # Bathymetry and land shapefiles ---------------------------------------------------------------  
@@ -53,7 +65,7 @@ get_base_layers <- function(select.region,
     akland <- sf::st_read(system.file("extdata", "ak_russia.shp", package = "akgfmaps"), quiet = TRUE)
     bathymetry <- sf::st_read(system.file("extdata", "npac_0-200_meters.shp", package = "akgfmaps"), quiet = TRUE)
     
-  } else if(select.region %in% c("ebs.slope")) {
+  } else if(select.region %in% c("ebs.slope", "bssa1", "bssa2", "bssa3", "bssa4", "bssa5", "bssa6")) {
     akland <- sf::st_read(system.file("extdata", "ak_russia.shp", package = "akgfmaps"), quiet = TRUE)
     bathymetry <- sf::st_read(system.file("extdata", "npac_0-1000_meters.shp", package = "akgfmaps"), quiet = TRUE)
   }
@@ -109,15 +121,28 @@ get_base_layers <- function(select.region,
   }    
   
   # EBS Slope --------------------------------------------------------------------------------------
-  if(select.region %in% c("ebs.slope")) {
+  if(select.region %in% c("ebs.slope", "bssa1", "bssa2", "bssa3", "bssa4", "bssa5", "bssa6")) {
     survey.area <- sf::st_read(system.file("extdata", "bssa_survey_boundary_2022.shp", package = "akgfmaps"), 
                                quiet = TRUE)
     survey.strata <- sf::st_read(system.file("extdata", "bssa1to6_2022.shp", package = "akgfmaps"), 
                                  quiet = TRUE) 
-    survey.grid <- NULL
     
+    survey.grid <- NULL
     lon.breaks <- seq(-180, -155, 5)
     lat.breaks <- seq(52, 64, 2)
+    
+    if(select.region %in% c("bssa1", "bssa2", "bssa3", "bssa4", "bssa5", "bssa6")) {
+      strata.temp <- survey.strata
+      subarea <- c(1,2,3,4,5,6)[match(select.region,  c("bssa1", "bssa2", "bssa3", "bssa4", "bssa5", "bssa6"))]
+      
+      survey.strata <- dplyr::filter(strata.temp, floor(STRATUM/10) %in% (subarea + c(-1,0,1)))
+      stratum.extent <- dplyr::filter(strata.temp, floor(STRATUM/10) == subarea)
+        
+      lon.breaks <- seq(-180, -155, 1)
+      lat.breaks <- seq(52, 64, 0.5) 
+    }
+    
+
   }
   
   
@@ -236,6 +261,10 @@ get_base_layers <- function(select.region,
   survey.area <- survey.area %>% sf::st_transform(crs = set.crs)
   survey.strata <- survey.strata %>% sf::st_transform(crs = set.crs)
   bathymetry <- bathymetry %>% sf::st_transform(crs = set.crs)
+  
+  if(exists("stratum.extent")) {
+    stratum.extent <- stratum.extent %>% sf::st_transform(crs = set.crs)
+  }
 
   
   # Set up survey grid -----------------------------------------------------------------------------
@@ -312,7 +341,12 @@ get_base_layers <- function(select.region,
                                 y = c(plot.boundary['ymin'], plot.boundary['ymax']))  
     
     
-  } else {
+  } else if(select.region %in% c("bssa1", "bssa2", "bssa3", "bssa4", "bssa5", "bssa6")) {
+    plot.boundary <- sf::st_bbox(stratum.extent)
+    plot.boundary <- data.frame(x = c(plot.boundary['xmin'], plot.boundary['xmax']),
+                                y = c(plot.boundary['ymin'], plot.boundary['ymax']))
+    
+    } else {
     plot.boundary <- sf::st_bbox(survey.area)
     plot.boundary <- data.frame(x = c(plot.boundary['xmin'], plot.boundary['xmax']),
                                 y = c(plot.boundary['ymin'], plot.boundary['ymax']))

--- a/README.md
+++ b/README.md
@@ -19,30 +19,16 @@ Vignettes can be accessed using:
 browseVignettes('akgfmaps')
 ```
 
-# Troubleshooting Installation: Compatibility with PROJ 6
-
-akgfmaps has limited backwards compatibility with old dependencies that do not include support for PROJ 6 strings (i.e., many versions of sp, sf, gstat, raster, and stars that were released before June 2020). To determine if you have the necessary dependencies installed, run the following in a new session:
-
-```{r}
-library(sf)
-```
-
 You should see a message indicating which versions of GEOS, GDAL, and PROJ are installed. If you have the necessary dependencies installed, versions should be: GEOS > 3.0.0, GDAL >3.0.0, and PROJ > 6.0.0. If version requirements are not met you will need to update sp, sf, gstat, rgdal, raster, and stars.
 
 # Troubleshooting Installation: Non-zero exit status
 
-If errors occur during installation, try to install dependencies separately then install the akgfmaps package. 
+If installation errors occur, try installing dependencies separately before installing the akgfmaps package. 
 
-Installation errors can occur when packages were built using different versions of R, which may result in non-zero exit status errors that will no affect functionality. Errors can sometimes be suppressed using
+Installation errors can occur when packages were built using different versions of R, which may result in non-zero exit status errors that will not affect functionality. Errors can sometimes be suppressed using
 
 ```{r}
 devtools::install_github("afsc-gap-products/akgfmaps", build_vignettes = TRUE, R_REMOTES_NO_ERRORS_FROM_WARNINGS="true")
-```
-
-or by temporarily changing system environment variables and installing:
-
-```{r}
-withr::with_envvar(c(R_REMOTES_NO_ERRORS_FROM_WARNINGS="true"), remotes::install_github('afsc-gap-products/akgfmaps'))
 ```
 
 ## Legal disclaimer

--- a/man/get_base_layers.Rd
+++ b/man/get_base_layers.Rd
@@ -11,7 +11,7 @@ get_base_layers(
 )
 }
 \arguments{
-\item{select.region}{Character vector indicating which region. Options = ebs or bs.all, sebs or bs.south, nbs or bs.north, ebs.slope, ecs, ebs.ecs, ai, ai.west, ai.central, ai.east, goa, goa.west, goa.east}
+\item{select.region}{Character vector indicating which region. Options = ebs or bs.all, sebs or bs.south, nbs or bs.north, ecs, ebs.ecs, ai, ai.west, ai.central, ai.east, goa, goa.west, goa.east, ebs.slope, bssa1, bssa2, bssa3, bssa4, bssa5, bssa6}
 
 \item{set.crs}{Which coordinate reference system should be used? If 'auto', an Albers Equal Area coordinate reference system is automatically assigned.}
 

--- a/vignettes/efficient_mapping.md
+++ b/vignettes/efficient_mapping.md
@@ -18,7 +18,7 @@ The following code shows how to use akgfmaps to quickly and efficiently make map
 ```r
 library(akgfmaps)
 
-akgfmaps:::YFS2017 %>% 
+akgfmaps::YFS2017 %>% 
   make_idw_map(region = "bs.all",
                set.breaks = "jenks",
                in.crs = "+proj=longlat",


### PR DESCRIPTION
Add default plotting options for EBS Slope subareas 1-6 ("bssa1", "bssa2", etc.). Example: retrieve EBS slope subarea 1 layers using get_base_layers(select.region = "bssa1")