### PR TITLE
Update make_idw_stack.R

### DIFF
--- a/R/make_idw_stack.R
+++ b/R/make_idw_stack.R
@@ -229,7 +229,7 @@ make_idw_stack <- function(x = NA,
         
       } else{
         
-        extrap.grid[grouping.vars] <- unique_groups[ii, ]
+        extrap.grid[grouping.vars] <- unlist(unique_groups)[ii]) # changed from unique_groups[ii, ]
         
       }
       

--- a/R/make_idw_stack.R
+++ b/R/make_idw_stack.R
@@ -229,7 +229,7 @@ make_idw_stack <- function(x = NA,
         
       } else{
         
-        extrap.grid[grouping.vars] <- unlist(unique_groups)[ii]) # changed from unique_groups[ii, ]
+        extrap.grid[grouping.vars] <- unlist(unique_groups)[ii] # changed from unique_groups[ii, ]
         
       }
       


### PR DESCRIPTION
Not sure why this little change (to `unlist(unique_groups)[ii])`, changed from `unique_groups[ii, ]`) is making the difference in my code runs (and only sometimes) but without it, I sometimes get the below error at the line I changed (currently 232):

```
[inverse distance weighted interpolation]
[inverse distance weighted interpolation]
Error in (function (cond)  : 
  error in evaluating the argument 'x' in selecting a method for function 'addAttrToGeom': subscript out of bounds
```