### PR TITLE
Bug fix get_nmfs_areas()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@ demo
 analysis
 paper
 plots
+archive

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: akgfmaps
 Type: Package
 Title: Alaska Groundfish and Ecosystem Survey Area Mapping
-Version: 3.5.2
+Version: 3.5.3
 Authors@R: c(person("Sean", "Rohan", email = "sean.rohan@noaa.gov", role = c("aut", "cre")),
     person("Emily", "Markowitz", email = "emily.markowitz@noaa.gov", role = "ctb"),
     person("Zack", "Oyafuso", email = "zack.oyafuso@noaa.gov", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+akgfmaps 3.5.3 (May 22, 2024)
+----------------------------------------------------------------
+
+BUG FIX
+
+- NMFS Statistical Area 659 is now included in the output of
+  get_nmfs_areas(). It had been erroneously not included in the
+  output.
+
+
 akgfmaps 3.5.2 (May 20, 2024)
 ----------------------------------------------------------------
 

--- a/R/get_nmfs_areas.R
+++ b/R/get_nmfs_areas.R
@@ -17,7 +17,7 @@ get_nmfs_areas <- function(set.crs) {
                 "NMFS Reporting Areas.shp",
                 package = "akgfmaps"),
     quiet = TRUE) |>
-    dplyr::filter(REP_AREA > 0 & REP_AREA < 651) |> # Select Alaska regions only and exclude land
+    dplyr::filter(REP_AREA > 0 & REP_AREA < 660) |> # Select Alaska regions only and exclude land
     sf::st_transform(crs = set.crs) |>
     sf::st_make_valid()
 


### PR DESCRIPTION
akgfmaps 3.5.3 (May 22, 2024)
----------------------------------------------------------------

BUG FIX

- NMFS Statistical Area 659 is now included in the output of
  get_nmfs_areas(). It had been erroneously not included in the
  output.