### PR TITLE
Remove include.corners (#163)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: akgfmaps
 Type: Package
 Title: Alaska Groundfish and Ecosystem Survey Area Mapping
-Version: 4.0.7
-Date: 2025-05-29
+Version: 4.0.8
+Date: 2025-07-03
 Authors@R: c(person("Sean", "Rohan", email = "sean.rohan@noaa.gov", role = c("aut", "cre")),
     person("Emily", "Markowitz", email = "emily.markowitz@noaa.gov", role = "ctb"),
     person("Zack", "Oyafuso", email = "zack.oyafuso@noaa.gov", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+akgfmaps 4.0.8 (July 3, 2025)
+----------------------------------------------------------------
+
+BUG FIX
+
+- Remove depreated include.corners argument from get_base_layers()
+  to align with the DESIGN_YEAR approach adopted in akgfmaps v4
+  (#163).
+
+
 akgfmaps 4.0.7 (May 29, 2025)
 ----------------------------------------------------------------
 

--- a/R/get_base_layers.R
+++ b/R/get_base_layers.R
@@ -6,7 +6,6 @@
 #' @param design.year Survey design year for files to retrieve. Returns the most recent year when NULL or closest year before the design year when there isn't an exact match.
 #' @param set.crs Which coordinate reference system should be used? If 'auto', Alaska Albers Equal Area (EPSG:3338) is used.
 #' @param use.survey.bathymetry Should survey bathymetry be used?
-#' @param include.corners Logical. Should corner stations be returned in the survey grid? Only for the EBS.
 #' @param fix.invalid.geom Should invalid geometries be corrected using st_make_valid() and st_wrap_dateline()?
 #' @param split.land.at.180 Logical. If set.crs is a geographic coordinate system, should the land polygon be split at 180 degrees to prevent polygons from wrapping around the world? Default = TRUE.
 #' @param high.resolution.coast Should the State of Alaska polygon be a high resolution Alaska Department of Natural Resources 1:63360 scale polygon that includes smaller islands and a more detailed coastline? The higher resolution polygon (high.resolution.coast = TRUE) takes longer to load/plot and is recommended for spatial operations performed at high resolution (e.g., masking high resolution rasters). The lower resolution polygon (high.resolution.coast = FALSE) is recommended for general mapping and visualization purposes. Default = FALSE.
@@ -39,13 +38,13 @@
 #'                      breaks = sebs$lat.breaks) +
 #'   theme_bw()
 #'
-#' # EBS bottom trawl survey layers in NAD83 (EPSG:4269) with corner stations and high resolution
+#' # EBS bottom trawl survey layers in NAD83 (EPSG:4269) with corner stations, 2022 design year survey strata, and high resolution
 #' # coastline. High resolution coastline takes longer to load and plot but is recommended when land
 #' # polygons are used for spatial analysis
 #'
 #' sebs_corners <- get_base_layers(select.region = "sebs",
 #'                                 set.crs = "EPSG:4269",
-#'                                 include.corners = TRUE,
+#'                                 design.year = 2022,
 #'                                 high.resolution.coast = TRUE)
 #'
 #' ggplot() +

--- a/man/get_base_layers.Rd
+++ b/man/get_base_layers.Rd
@@ -24,8 +24,6 @@ get_base_layers(
 
 \item{use.survey.bathymetry}{Should survey bathymetry be used?}
 
-\item{include.corners}{Logical. Should corner stations be returned in the survey grid? Only for the EBS.}
-
 \item{split.land.at.180}{Logical. If set.crs is a geographic coordinate system, should the land polygon be split at 180 degrees to prevent polygons from wrapping around the world? Default = TRUE.}
 
 \item{fix.invalid.geom}{Should invalid geometries be corrected using st_make_valid() and st_wrap_dateline()?}
@@ -64,13 +62,13 @@ ggplot() +
                      breaks = sebs$lat.breaks) +
   theme_bw()
 
-# EBS bottom trawl survey layers in NAD83 (EPSG:4269) with corner stations and high resolution
+# EBS bottom trawl survey layers in NAD83 (EPSG:4269) with corner stations, 2022 design year survey strata, and high resolution
 # coastline. High resolution coastline takes longer to load and plot but is recommended when land
 # polygons are used for spatial analysis
 
 sebs_corners <- get_base_layers(select.region = "sebs",
                                 set.crs = "EPSG:4269",
-                                include.corners = TRUE,
+                                design.year = 2022,
                                 high.resolution.coast = TRUE)
 
 ggplot() +


### PR DESCRIPTION
akgfmaps 4.0.8 (July 3, 2025)
----------------------------------------------------------------

BUG FIX

- Remove depreated include.corners argument from get_base_layers()
  to align with the DESIGN_YEAR approach adopted in akgfmaps v4
  (#163).