### PR TITLE
Remove include.corner (#163)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,9 @@
-akgfmaps 4.0.8 (July 3, 2025)
+akgfmaps 4.0.8 (July 9, 2025)
 ----------------------------------------------------------------
 
 BUG FIX
 
-- Remove depreated include.corners argument from get_base_layers()
+- Remove deprecated include.corners argument from get_base_layers()
   to align with the DESIGN_YEAR approach adopted in akgfmaps v4
   (#163).
 

--- a/R/get_base_layers.R
+++ b/R/get_base_layers.R
@@ -91,7 +91,6 @@ get_base_layers <- function(select.region,
                             design.year = NULL,
                             set.crs = "EPSG:4269",
                             use.survey.bathymetry = TRUE,
-                            include.corners = FALSE,
                             split.land.at.180 = TRUE,
                             fix.invalid.geom = TRUE,
                             high.resolution.coast = FALSE) {

--- a/man/get_base_layers.Rd
+++ b/man/get_base_layers.Rd
@@ -9,7 +9,6 @@ get_base_layers(
   design.year = NULL,
   set.crs = "EPSG:4269",
   use.survey.bathymetry = TRUE,
-  include.corners = FALSE,
   split.land.at.180 = TRUE,
   fix.invalid.geom = TRUE,
   high.resolution.coast = FALSE


### PR DESCRIPTION
akgfmaps 4.0.8 (July 9, 2025)
----------------------------------------------------------------

BUG FIX

- Remove deprecated include.corners argument from get_base_layers()
  to align with the DESIGN_YEAR approach adopted in akgfmaps v4
  (#163).